### PR TITLE
Add support for async main

### DIFF
--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -52,7 +52,10 @@ pub fn split_input(
             let (manifest, source) =
                 find_embedded_manifest(content).unwrap_or((Manifest::Toml(""), content));
 
-            let source = if source.lines().any(|line| line.starts_with("fn main()")) {
+            let source = if source
+                .lines()
+                .any(|line| line.starts_with("fn main()") || line.starts_with("async fn main()"))
+            {
                 source.to_string()
             } else {
                 format!("fn main() -> Result<(), Box<dyn std::error::Error+Sync+Send>> {{\n    {{\n    {}    }}\n    Ok(())\n}}", source)

--- a/tests/data/script-async-main.rs
+++ b/tests/data/script-async-main.rs
@@ -1,0 +1,14 @@
+//! This is merged into a default manifest in order to form the full package manifest:
+//!
+//! ```cargo
+//! [dependencies]
+//! boolinator = "=0.1.0"
+//! tokio = { version = "1", features = ["full"] }
+//! ```
+use boolinator::Boolinator;
+
+#[tokio::main]
+async fn main() {
+    println!("--output--");
+    println!("{:?}", true.as_some(1));
+}

--- a/tests/tests/script.rs
+++ b/tests/tests/script.rs
@@ -152,3 +152,12 @@ fn script_without_main_question_mark() {
         .stderr
         .starts_with("Error: Os { code: 2, kind: NotFound, message:"));
 }
+
+#[test]
+fn test_script_async_main() {
+    let out = rust_script!("tests/data/script-async-main.rs").unwrap();
+    scan!(out.stdout_output();
+        ("Some(1)") => ()
+    )
+    .unwrap()
+}


### PR DESCRIPTION
It enables it to notice `async fn main` so it won't wrap the script into a synchronous one instead