### PR TITLE
Allow indentation before fn main()

### DIFF
--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -45,6 +45,7 @@ pub fn split_input(
     input_id: &OsString,
 ) -> MainResult<(String, String)> {
     fn contains_main_method(line: &str) -> bool {
+        let line = line.trim_start();
         line.starts_with("fn main()")
             || line.starts_with("pub fn main()")
             || line.starts_with("async fn main()")


### PR DESCRIPTION
Some scripts (specially ones using [cargo-make](https://github.com/sagiegurari/cargo-make)) may indent the whole script, and thus `fn main()`. [A script](https://github.com/vita-rust/common/blob/27ad0caee88d7d722bb20bf2bc69636cb60d6114/common.toml#L50) from 2018 I found wasn't working.

Thanks a lot!