### PR TITLE
Add `--toolchain-version` argument

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -808,13 +808,13 @@ fn decide_action_for(
     };
     info!("input_meta: {:?}", input_meta);
 
-    let toolchain_version = args.toolchain_version.clone().or_else(|| {
-        if matches!(args.build_kind, BuildKind::Bench) {
-            Some("nightly".into())
-        } else {
-            None
-        }
-    });
+    let toolchain_version = args
+        .toolchain_version
+        .clone()
+        .or_else(|| match args.build_kind {
+            BuildKind::Bench => Some("nightly".into()),
+            _ => None,
+        });
 
     let mut action = InputAction {
         cargo_output: args.cargo_output,

--- a/tests/data/script-unstable-feature.rs
+++ b/tests/data/script-unstable-feature.rs
@@ -1,0 +1,6 @@
+#![feature(lang_items)]
+
+fn main() {
+    println!("--output--");
+    println!("`#![feature]` *may* be used!");
+}

--- a/tests/tests/script.rs
+++ b/tests/tests/script.rs
@@ -179,3 +179,20 @@ fn test_whitespace_before_main() {
     )
     .unwrap()
 }
+
+#[test]
+fn test_stable_toolchain() {
+    let out = rust_script!("--toolchain-version", "stable", "tests/data/script-unstable-feature.rs").unwrap();
+    assert!(out.stderr.contains("`#![feature]` may not be used"));
+    assert!(!out.success());
+}
+
+#[test]
+fn test_nightly_toolchain() {
+    let out = rust_script!("--toolchain-version", "nightly", "tests/data/script-unstable-feature.rs").unwrap();
+    scan!(out.stdout_output();
+        ("`#![feature]` *may* be used!") => ()
+    )
+    .unwrap();
+    assert!(out.success());
+}


### PR DESCRIPTION
This allows the user to specify which toolchain to use to build their script. This allows for the use of nightly features, features only stabilized in beta (without resorting to nightly), and even the use of custom-built toolchains if the need ever arises.