### PR TITLE
Avoid exporting CARGO_TARGET_DIR (fixes #27)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1177,7 +1177,8 @@ fn cargo(
     }
 
     let cargo_target_dir = format!("{}", platform::binary_cache_path()?.display(),);
-    cmd.env("CARGO_TARGET_DIR", cargo_target_dir);
+    cmd.arg("--target-dir");
+    cmd.arg(cargo_target_dir);
 
     // Block `--release` on `bench`.
     if !meta.debug && cmd_name != "bench" {

--- a/tests/data/cargo-target-dir-env.rs
+++ b/tests/data/cargo-target-dir-env.rs
@@ -1,0 +1,13 @@
+use std::env;
+
+pub fn main() {
+    // Test that CARGO_TARGET_DIR is not set by rust-script to avoid
+    // interfering with cargo calls done by the script.
+    // See https://github.com/fornwall/rust-script/issues/27
+    let env_variable = env::var("CARGO_TARGET_DIR");
+    println!("--output--");
+    println!(
+        "{:?}",
+        matches!(env_variable, Err(env::VarError::NotPresent))
+    );
+}

--- a/tests/tests/script.rs
+++ b/tests/tests/script.rs
@@ -172,12 +172,21 @@ fn test_pub_fn_main() {
 }
 
 #[test]
+fn test_cargo_target_dir_env() {
+    let out = rust_script!("tests/data/cargo-target-dir-env.rs").unwrap();
+    scan!(out.stdout_output();
+        ("true") => ()
+    )
+    .unwrap()
+}
+
+#[test]
 fn test_outer_line_doc() {
     let out = rust_script!("tests/data/outer-line-doc.rs").unwrap();
     scan!(out.stdout_output();
         ("Some(1)") => ()
     )
-        .unwrap()
+    .unwrap()
 }
 
 #[test]


### PR DESCRIPTION
Use the `--target-dir` cargo CLI option instead of exporting the `CARGO_TARGET_DIR` environment variable to avoid interfering with cargo calls done by the script.