### PR TITLE
Allow main function with arguments

### DIFF
--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -46,10 +46,10 @@ pub fn split_input(
 ) -> MainResult<(String, String)> {
     fn contains_main_method(line: &str) -> bool {
         let line = line.trim_start();
-        line.starts_with("fn main()")
-            || line.starts_with("pub fn main()")
-            || line.starts_with("async fn main()")
-            || line.starts_with("pub async fn main()")
+        line.starts_with("fn main(")
+            || line.starts_with("pub fn main(")
+            || line.starts_with("async fn main(")
+            || line.starts_with("pub async fn main(")
     }
 
     let template_buf;


### PR DESCRIPTION
This changes the check for whether the code contains a `main` function to match `main` functions with arguments, which can be useful for parsing command-line parameters with [`paw`](https://docs.rs/paw).