### PR TITLE
Enable strip binary on release build

### DIFF
--- a/src/consts.rs
+++ b/src/consts.rs
@@ -147,6 +147,9 @@ edition = "2018"
 [[bin]]
 name = "#{bin_name}"
 path = "#{file}.rs"
+
+[profile.release]
+strip = true
 "##;
 
 /**

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -158,6 +158,8 @@ authors = ["Anonymous"]
 edition = "2018"
 name = "n"
 version = "0.1.0"
+[profile.release]
+strip = true
 "#,
             r#"fn main() {}"#
         )
@@ -181,6 +183,8 @@ authors = ["Anonymous"]
 edition = "2018"
 name = "n"
 version = "0.1.0"
+[profile.release]
+strip = true
 "#,
             r#"
 ---
@@ -207,6 +211,8 @@ authors = ["Anonymous"]
 edition = "2018"
 name = "n"
 version = "0.1.0"
+[profile.release]
+strip = true
 "#,
             r#"[dependencies]
 time="0.1.25"
@@ -234,6 +240,8 @@ authors = ["Anonymous"]
 edition = "2018"
 name = "n"
 version = "0.1.0"
+[profile.release]
+strip = true
 "#,
             r#"
 // Cargo-Deps: time="0.1.25"
@@ -261,6 +269,8 @@ authors = ["Anonymous"]
 edition = "2018"
 name = "n"
 version = "0.1.0"
+[profile.release]
+strip = true
 "#,
             r#"
 // Cargo-Deps: time="0.1.25", libc="0.2.5"
@@ -294,6 +304,8 @@ authors = ["Anonymous"]
 edition = "2018"
 name = "n"
 version = "0.1.0"
+[profile.release]
+strip = true
 "#,
             r#"
 /*!


### PR DESCRIPTION
This PR is to enable stripping option on the release build of the generated cargo project. Resolves #36

## Comparison of built binary
It actually works, and the binary size of a hello world program reduced from 3.5M to 300K.
```bash
$ ./rust-script-no-strip --clear-cache ./hello.rs
Hello world!
$ file $binary
/home/misawa/.cache/rust-script/binaries/release/hello_59500b17925d6a21fe59ae0b: ELF 64-bit LSB pie executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, BuildID[sha1]=da41165504c484ad9734ded644b275ae7d4c2030, for GNU/Linux 4.4.0, with debug_info, not stripped
$ du $binary
3.5M    /home/misawa/.cache/rust-script/binaries/release/hello_59500b17925d6a21fe59ae0b
$ ./rust-script-with-strip --clear-cache ./hello.rs
Hello world!
$ file $binary
/home/misawa/.cache/rust-script/binaries/release/hello_59500b17925d6a21fe59ae0b: ELF 64-bit LSB pie executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, BuildID[sha1]=558091b50cb49c7c88877998d454b9bda928a973, for GNU/Linux 4.4.0, stripped
$ du $binary
300K    /home/misawa/.cache/rust-script/binaries/release/hello_59500b17925d6a21fe59ae0b
```

## Comparison of build+run time
I'd say they're the same.

```bash
$ hyperfine './rust-script-no-strip --clear-cache ./hello.rs' './rust-script-with-strip --clear-cache ./hello.rs' -w 10
Benchmark 1: ./rust-script-no-strip --clear-cache ./hello.rs
  Time (mean ± σ):      1.114 s ±  0.066 s    [User: 0.946 s, System: 0.180 s]
  Range (min … max):    1.050 s …  1.253 s    10 runs
 
Benchmark 2: ./rust-script-with-strip --clear-cache ./hello.rs
  Time (mean ± σ):      1.051 s ±  0.035 s    [User: 0.882 s, System: 0.186 s]
  Range (min … max):    1.006 s …  1.128 s    10 runs
 
Summary
  './rust-script-with-strip --clear-cache ./hello.rs' ran
    1.06 ± 0.07 times faster than './rust-script-no-strip --clear-cache ./hello.rs'
```

## Compatibilities
Works fine (I mean, just a warning message that's shown only when you passed `-o`) when used with older version of cargo.

```bash
$ rustup default 1.42.0-x86_64-unknown-linux-gnu
info: using existing install for '1.42.0-x86_64-unknown-linux-gnu'
info: default toolchain set to '1.42.0-x86_64-unknown-linux-gnu'

  1.42.0-x86_64-unknown-linux-gnu unchanged - rustc 1.42.0 (b8cedc004 2020-03-09)

$ ./rust-script-with-strip --clear-cache -o ./hello.rs
warning: unused manifest key: profile.release.strip
   Compiling hello v0.1.0 (/home/misawa/.cache/rust-script/projects/59500b17925d6a21fe59ae0b)
    Finished release [optimized] target(s) in 0.79s
     Running `/home/misawa/.cache/rust-script/binaries/release/hello_59500b17925d6a21fe59ae0b`
Hello world!
```

## Other consideration
I don't have Windows / Mac OSX, so unsure how it perform on those environment.