### PR TITLE
Correct minimal rust version in docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -35,7 +35,7 @@ Install or update `rust-script` using Cargo:
 cargo install rust-script
 ```
 
-Rust 1.47 or later is required.
+Rust 1.54 or later is required.
 
 ### Distro Packages
 


### PR DESCRIPTION
I'm guessing this is a oversight. :)