### PR TITLE
Use Rust 2021 edition as default

### DIFF
--- a/src/consts.rs
+++ b/src/consts.rs
@@ -147,7 +147,7 @@ pub const DEFAULT_MANIFEST: &str = r##"
 name = "#{name}"
 version = "0.1.0"
 authors = ["Anonymous"]
-edition = "2018"
+edition = "2021"
 
 [[bin]]
 name = "#{bin_name}"
@@ -159,7 +159,7 @@ pub const DEFAULT_MANIFEST: &str = r##"
 name = "#{name}"
 version = "0.1.0"
 authors = ["Anonymous"]
-edition = "2018"
+edition = "2021"
 
 [[bin]]
 name = "#{bin_name}"

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -167,7 +167,7 @@ path = "n.rs"
 
 [package]
 authors = ["Anonymous"]
-edition = "2018"
+edition = "2021"
 name = "n"
 version = "0.1.0""#,
                 STRIP_SECTION
@@ -193,7 +193,7 @@ path = "n.rs"
 
 [package]
 authors = ["Anonymous"]
-edition = "2018"
+edition = "2021"
 name = "n"
 version = "0.1.0""#,
                 STRIP_SECTION
@@ -222,7 +222,7 @@ path = "n.rs"
 
 [package]
 authors = ["Anonymous"]
-edition = "2018"
+edition = "2021"
 name = "n"
 version = "0.1.0""#,
                 STRIP_SECTION
@@ -252,7 +252,7 @@ time = "0.1.25"
 
 [package]
 authors = ["Anonymous"]
-edition = "2018"
+edition = "2021"
 name = "n"
 version = "0.1.0""#,
                 STRIP_SECTION
@@ -282,7 +282,7 @@ time = "0.1.25"
 
 [package]
 authors = ["Anonymous"]
-edition = "2018"
+edition = "2021"
 name = "n"
 version = "0.1.0""#,
                 STRIP_SECTION
@@ -318,7 +318,7 @@ time = "0.1.25"
 
 [package]
 authors = ["Anonymous"]
-edition = "2018"
+edition = "2021"
 name = "n"
 version = "0.1.0""#,
                 STRIP_SECTION


### PR DESCRIPTION
I think it is better to use the latest Rust edition as default. It eliminates the need of specifying it manually like in #56
