### PR TITLE
Replace atty with is-terminal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,17 +52,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -269,15 +258,6 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
@@ -313,7 +293,7 @@ version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09270fd4fa1111bc614ed2246c7ef56239a3063d5be0d1ec3b589c505d400aeb"
 dependencies = [
- "hermit-abi 0.3.1",
+ "hermit-abi",
  "libc",
  "windows-sys",
 ]
@@ -324,7 +304,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "256017f749ab3117e93acb91063009e1f1bb56d03965b14c2c8df4eb02c524d8"
 dependencies = [
- "hermit-abi 0.3.1",
+ "hermit-abi",
  "io-lifetimes",
  "rustix",
  "windows-sys",
@@ -455,10 +435,10 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 name = "rust-script"
 version = "0.24.0"
 dependencies = [
- "atty",
  "clap",
  "dirs-next",
  "env_logger",
+ "is-terminal",
  "lazy_static 1.4.0",
  "log",
  "pulldown-cmark",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ toml = "0.7"
 winreg = "0.11"
 
 [target.'cfg(unix)'.dependencies]
-atty = "0.2"
+is-terminal = "0.4.6"
 
 [dev-dependencies]
 lazy_static = "1"

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -9,6 +9,8 @@ use std::fs;
 use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use is_terminal::IsTerminal as _;
+
 // Last-modified time of a directory, in milliseconds since the UNIX epoch.
 pub fn dir_last_modified(dir: &fs::DirEntry) -> u128 {
     dir.metadata()
@@ -62,7 +64,7 @@ mod inner {
     This depends on whether `rust-script`'s STDERR is connected to a TTY or not.
     */
     pub fn force_cargo_color() -> bool {
-        atty::is(atty::Stream::Stderr)
+        std::io::stderr().is_terminal()
     }
 }
 


### PR DESCRIPTION
As atty is unmaintained, replaces atty with is-terminal.