### PR TITLE
Replace sha-1 with sha1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,7 +444,7 @@ dependencies = [
  "pulldown-cmark",
  "regex",
  "scan-rules",
- "sha-1",
+ "sha1",
  "tempfile",
  "toml",
  "winreg",
@@ -507,10 +507,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha-1"
-version = "0.10.1"
+name = "sha1"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
+checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
 dependencies = [
  "cfg-if",
  "cpufeatures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ env_logger = "0.10"
 log = "0.4"
 pulldown-cmark = "0.9"
 regex = "1"
-sha-1 = "0.10"
+sha1 = "0.10"
 tempfile = "3"
 toml = "0.7"
 


### PR DESCRIPTION
As sha-1 has changed its crate to sha1 in [0.10.0](https://github.com/RustCrypto/hashes/blob/sha1-v0.10.0/sha1/CHANGELOG.md#0100-2022-01-17), replaces sha-1 with sha1.