### PR TITLE
Check for .exe on Windows

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -339,7 +339,16 @@ impl InputAction {
 
         let built_binary_path = platform::binary_cache_path()
             .join(if release_mode { "release" } else { "debug" })
-            .join(&self.bin_name);
+            .join({
+                #[cfg(windows)]
+                {
+                    format!("{}.exe", &self.bin_name)
+                }
+                #[cfg(not(windows))]
+                {
+                    &self.bin_name
+                }
+            });
 
         let manifest_path = self.manifest_path();
 

--- a/tests/data/script-using-env.rs
+++ b/tests/data/script-using-env.rs
@@ -1,0 +1,4 @@
+let msg = option_env!("_RUST_SCRIPT_TEST_MESSAGE").unwrap_or("undefined");
+
+println!("--output--");
+println!("msg = {}", msg);

--- a/tests/tests/script.rs
+++ b/tests/tests/script.rs
@@ -187,6 +187,34 @@ fn test_whitespace_before_main() {
 }
 
 #[test]
+fn test_force_rebuild() {
+    for option in ["-f", "--force"] {
+        std::env::remove_var("_RUST_SCRIPT_TEST_MESSAGE");
+
+        let script_path = "tests/data/script-using-env.rs";
+        let out = rust_script!(option, script_path).unwrap();
+        scan!(out.stdout_output();
+            ("msg = undefined") => ()
+        )
+        .unwrap();
+
+        std::env::set_var("_RUST_SCRIPT_TEST_MESSAGE", "hello");
+
+        let out = rust_script!(script_path).unwrap();
+        scan!(out.stdout_output();
+            ("msg = undefined") => ()
+        )
+        .unwrap();
+
+        let out = rust_script!(option, script_path).unwrap();
+        scan!(out.stdout_output();
+            ("msg = hello") => ()
+        )
+        .unwrap();
+    }
+}
+
+#[test]
 #[ignore]
 fn test_stable_toolchain() {
     let out = rust_script!(


### PR DESCRIPTION
Avoids always rebuilding the executable on Windows.

Thanks @epage for pointing this out [here](https://github.com/fornwall/rust-script/pull/73#discussion_r1157921746)!
