### PR TITLE
Use the source input file as bin path if possible

### DIFF
--- a/src/consts.rs
+++ b/src/consts.rs
@@ -14,8 +14,13 @@ pub const SCRIPT_BODY_SUB: &str = "script";
 /// Substitution for the script prelude.
 pub const SCRIPT_PRELUDE_SUB: &str = "prelude";
 
-/// The template used for script file inputs.
-pub const FILE_TEMPLATE: &str = r#"#{script}"#;
+/// The template used for script file inputs that doesn't have main function.
+pub const FILE_NO_MAIN_TEMPLATE: &str = r#"
+fn main() -> Result<(), Box<dyn std::error::Error+Sync+Send>> {
+    {#{script}}
+    Ok(())
+}
+"#;
 
 /// The template used for `--expr` input.
 pub const EXPR_TEMPLATE: &str = r#"

--- a/src/main.rs
+++ b/src/main.rs
@@ -362,7 +362,10 @@ impl InputAction {
                     // Use ctime instead of mtime as cargo may copy an already
                     // built binary (with old mtime) here:
                     let built_binary_ctime = built_binary_file.metadata()?.created()?;
-                    match (fs::File::open(&self.script_path), fs::File::open(manifest_path)) {
+                    match (
+                        fs::File::open(&self.script_path),
+                        fs::File::open(manifest_path),
+                    ) {
                         (Ok(script_file), Ok(manifest_file)) => {
                             let script_mtime = script_file.metadata()?.modified()?;
                             let manifest_mtime = manifest_file.metadata()?.modified()?;

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -134,7 +134,7 @@ fn test_split_input() {
                 &$i,
                 &[],
                 &[],
-                "",
+                "/package",
                 &bin_name,
                 &script_name,
                 toolchain.clone(),
@@ -144,13 +144,13 @@ fn test_split_input() {
     }
 
     let f = |c: &str| {
-        let dummy_path: ::std::path::PathBuf = "main.rs".into();
+        let dummy_path: ::std::path::PathBuf = "/dummy/main.rs".into();
         Input::File("n".to_string(), dummy_path, c.to_string())
     };
 
     macro_rules! r {
-        ($m:expr, $r:expr) => {
-            Some(($m.into(), "main.rs".into(), $r.into()))
+        ($m:expr, $p:expr, $r:expr) => {
+            Some(($m.into(), $p.into(), $r.into()))
         };
     }
 
@@ -161,7 +161,7 @@ fn test_split_input() {
                 "{}{}",
                 r#"[[bin]]
 name = "binary-name"
-path = "main.rs"
+path = "/dummy/main.rs"
 
 [dependencies]
 
@@ -172,6 +172,7 @@ name = "n"
 version = "0.1.0""#,
                 STRIP_SECTION
             ),
+            "/dummy/main.rs",
             None
         )
     );
@@ -184,7 +185,7 @@ fn main() {}"#)),
                 "{}{}",
                 r#"[[bin]]
 name = "binary-name"
-path = "main.rs"
+path = "/dummy/main.rs"
 
 [dependencies]
 
@@ -195,6 +196,7 @@ name = "n"
 version = "0.1.0""#,
                 STRIP_SECTION
             ),
+            "/dummy/main.rs",
             None
         )
     );
@@ -207,7 +209,7 @@ fn main() {}"#)),
                 "{}{}",
                 r#"[[bin]]
 name = "binary-name"
-path = "main.rs"
+path = "/dummy/main.rs"
 
 [dependencies]
 
@@ -218,6 +220,7 @@ name = "n"
 version = "0.1.0""#,
                 STRIP_SECTION
             ),
+            "/dummy/main.rs",
             None
         )
     );
@@ -238,7 +241,7 @@ version = "0.1.0""#,
                 "{}{}",
                 r#"[[bin]]
 name = "binary-name"
-path = "main.rs"
+path = "/dummy/main.rs"
 
 [dependencies]
 
@@ -252,6 +255,7 @@ version = "0.1.0"
 toolchain = "stable""#,
                 STRIP_SECTION
             ),
+            "/dummy/main.rs",
             None
         )
     );
@@ -267,7 +271,7 @@ fn main() {}
                 "{}{}",
                 r#"[[bin]]
 name = "binary-name"
-path = "main.rs"
+path = "/dummy/main.rs"
 
 [dependencies]
 
@@ -278,6 +282,7 @@ name = "n"
 version = "0.1.0""#,
                 STRIP_SECTION
             ),
+            "/dummy/main.rs",
             None
         )
     );
@@ -293,7 +298,7 @@ fn main() {}
                 "{}{}",
                 r#"[[bin]]
 name = "binary-name"
-path = "main.rs"
+path = "/dummy/main.rs"
 
 [dependencies]
 
@@ -304,6 +309,7 @@ name = "n"
 version = "0.1.0""#,
                 STRIP_SECTION
             ),
+            "/dummy/main.rs",
             None
         )
     );
@@ -318,7 +324,7 @@ fn main() {}
                 "{}{}",
                 r#"[[bin]]
 name = "binary-name"
-path = "main.rs"
+path = "/dummy/main.rs"
 
 [dependencies]
 time = "0.1.25"
@@ -330,6 +336,7 @@ name = "n"
 version = "0.1.0""#,
                 STRIP_SECTION
             ),
+            "/dummy/main.rs",
             None
         )
     );
@@ -344,7 +351,7 @@ fn main() {}
                 "{}{}",
                 r#"[[bin]]
 name = "binary-name"
-path = "main.rs"
+path = "/dummy/main.rs"
 
 [dependencies]
 libc = "0.2.5"
@@ -357,6 +364,7 @@ name = "n"
 version = "0.1.0""#,
                 STRIP_SECTION
             ),
+            "/dummy/main.rs",
             None
         )
     );
@@ -378,7 +386,7 @@ fn main() {}
                 "{}{}",
                 r#"[[bin]]
 name = "binary-name"
-path = "main.rs"
+path = "/dummy/main.rs"
 
 [dependencies]
 time = "0.1.25"
@@ -390,7 +398,37 @@ name = "n"
 version = "0.1.0""#,
                 STRIP_SECTION
             ),
+            "/dummy/main.rs",
             None
+        )
+    );
+
+    assert_eq!(
+        si!(f(r#"#!/usr/bin/env rust-script
+println!("Hello")"#)),
+        r!(
+            format!(
+                "{}{}",
+                r#"[[bin]]
+name = "binary-name"
+path = "/package/main.rs"
+
+[dependencies]
+
+[package]
+authors = ["Anonymous"]
+edition = "2021"
+name = "n"
+version = "0.1.0""#,
+                STRIP_SECTION
+            ),
+            "/package/main.rs",
+            Some(r#"
+fn main() -> Result<(), Box<dyn std::error::Error+Sync+Send>> {
+    {println!("Hello")}
+    Ok(())
+}
+"#.to_string())
         )
     );
 }

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -45,7 +45,13 @@ pub fn split_input(
             if contains_main_method(content) {
                 (manifest, path.clone(), source.to_string(), None, false)
             } else {
-                (manifest, source_in_package, content.to_string(), Some(consts::FILE_NO_MAIN_TEMPLATE), false)
+                (
+                    manifest,
+                    source_in_package,
+                    content.to_string(),
+                    Some(consts::FILE_NO_MAIN_TEMPLATE),
+                    false,
+                )
             }
         }
         Input::Expr(content) => (
@@ -83,12 +89,16 @@ pub fn split_input(
         subs.insert(consts::SCRIPT_PRELUDE_SUB, &prelude_str[..]);
     }
 
-    let source = template.map(|template| templates::expand(template, &subs)).transpose()?;
+    let source = template
+        .map(|template| templates::expand(template, &subs))
+        .transpose()?;
     let part_mani = part_mani.into_toml()?;
     info!("part_mani: {:?}", part_mani);
     info!("source: {:?}", source);
 
-    let source_path_str = source_path.to_str().ok_or_else(|| format!("Unable to stringify {source_path:?}"))?;
+    let source_path_str = source_path
+        .to_str()
+        .ok_or_else(|| format!("Unable to stringify {source_path:?}"))?;
 
     // It's-a mergin' time!
     let def_mani = default_manifest(input, bin_name, source_path_str, toolchain);
@@ -120,7 +130,16 @@ fn test_split_input() {
     let toolchain = None;
     macro_rules! si {
         ($i:expr) => {
-            split_input(&$i, &[], &[], "", &bin_name, &script_name, toolchain.clone()).ok()
+            split_input(
+                &$i,
+                &[],
+                &[],
+                "",
+                &bin_name,
+                &script_name,
+                toolchain.clone(),
+            )
+            .ok()
         };
     }
 

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -6,6 +6,7 @@ use regex;
 use self::regex::Regex;
 use std::collections::HashMap;
 use std::path::Path;
+use std::path::PathBuf;
 
 use crate::consts;
 use crate::error::{MainError, MainResult};
@@ -22,48 +23,47 @@ pub fn split_input(
     input: &Input,
     deps: &[(String, String)],
     prelude_items: &[String],
+    package_path: impl AsRef<Path>,
     bin_name: &str,
     script_name: &str,
     toolchain: Option<String>,
-) -> MainResult<(String, String)> {
+) -> MainResult<(String, PathBuf, Option<String>)> {
     fn contains_main_method(source: &str) -> bool {
         let re_shebang: Regex =
             Regex::new(r#"(?m)^ *(pub )?(async )?(extern "C" )?fn main *\("#).unwrap();
         re_shebang.is_match(source)
     }
 
-    let (part_mani, source, template, sub_prelude) = match input {
-        Input::File(_, _, content) => {
+    let source_in_package = package_path.as_ref().join(script_name);
+    let (part_mani, source_path, source, template, sub_prelude) = match input {
+        Input::File(_, path, content) => {
             assert_eq!(prelude_items.len(), 0);
-            let (content, shebang_used) = strip_shebang(content);
+            let content = strip_shebang(content);
             let (manifest, source) =
                 find_embedded_manifest(content).unwrap_or((Manifest::Toml(""), content));
 
-            let source = if contains_main_method(source) {
-                if shebang_used {
-                    format!("//\n{}", source)
-                } else {
-                    source.to_string()
-                }
+            if contains_main_method(content) {
+                (manifest, path.clone(), source.to_string(), None, false)
             } else {
-                format!("fn main() -> Result<(), Box<dyn std::error::Error+Sync+Send>> {{    {{\n{}    }}\n    Ok(())\n}}", source)
-            };
-            (manifest, source, consts::FILE_TEMPLATE, false)
+                (manifest, source_in_package, content.to_string(), Some(consts::FILE_NO_MAIN_TEMPLATE), false)
+            }
         }
         Input::Expr(content) => (
             Manifest::Toml(""),
+            source_in_package,
             content.to_string(),
-            consts::EXPR_TEMPLATE,
+            Some(consts::EXPR_TEMPLATE),
             true,
         ),
         Input::Loop(content, count) => (
             Manifest::Toml(""),
+            source_in_package,
             content.to_string(),
-            if *count {
+            Some(if *count {
                 consts::LOOP_COUNT_TEMPLATE
             } else {
                 consts::LOOP_TEMPLATE
-            },
+            }),
             true,
         ),
     };
@@ -83,13 +83,15 @@ pub fn split_input(
         subs.insert(consts::SCRIPT_PRELUDE_SUB, &prelude_str[..]);
     }
 
-    let source = templates::expand(template, &subs)?;
+    let source = template.map(|template| templates::expand(template, &subs)).transpose()?;
     let part_mani = part_mani.into_toml()?;
     info!("part_mani: {:?}", part_mani);
     info!("source: {:?}", source);
 
+    let source_path_str = source_path.to_str().ok_or_else(|| format!("Unable to stringify {source_path:?}"))?;
+
     // It's-a mergin' time!
-    let def_mani = default_manifest(input, bin_name, script_name, toolchain);
+    let def_mani = default_manifest(input, bin_name, source_path_str, toolchain);
     let dep_mani = deps_manifest(deps)?;
 
     let mani = merge_manifest(def_mani, part_mani)?;
@@ -101,7 +103,7 @@ pub fn split_input(
     let mani_str = format!("{}", mani);
     info!("manifest: {}", mani_str);
 
-    Ok((mani_str, source))
+    Ok((mani_str, source_path, source))
 }
 
 #[cfg(test)]
@@ -118,7 +120,7 @@ fn test_split_input() {
     let toolchain = None;
     macro_rules! si {
         ($i:expr) => {
-            split_input(&$i, &[], &[], &bin_name, &script_name, toolchain.clone()).ok()
+            split_input(&$i, &[], &[], "", &bin_name, &script_name, toolchain.clone()).ok()
         };
     }
 
@@ -129,7 +131,7 @@ fn test_split_input() {
 
     macro_rules! r {
         ($m:expr, $r:expr) => {
-            Some(($m.into(), $r.into()))
+            Some(($m.into(), "main.rs".into(), $r.into()))
         };
     }
 
@@ -151,7 +153,7 @@ name = "n"
 version = "0.1.0""#,
                 STRIP_SECTION
             ),
-            r#"fn main() {}"#
+            None
         )
     );
 
@@ -174,8 +176,7 @@ name = "n"
 version = "0.1.0""#,
                 STRIP_SECTION
             ),
-            r#"//
-fn main() {}"#
+            None
         )
     );
 
@@ -198,8 +199,7 @@ name = "n"
 version = "0.1.0""#,
                 STRIP_SECTION
             ),
-            r#"#[thingy]
-fn main() {}"#
+            None
         )
     );
 
@@ -208,6 +208,7 @@ fn main() {}"#
             &f(r#"fn main() {}"#),
             &[],
             &[],
+            "",
             &bin_name,
             "main.rs",
             Some("stable".to_string())
@@ -232,7 +233,7 @@ version = "0.1.0"
 toolchain = "stable""#,
                 STRIP_SECTION
             ),
-            r#"fn main() {}"#
+            None
         )
     );
 
@@ -258,10 +259,7 @@ name = "n"
 version = "0.1.0""#,
                 STRIP_SECTION
             ),
-            r#"
----
-fn main() {}
-"#
+            None
         )
     );
 
@@ -287,11 +285,7 @@ name = "n"
 version = "0.1.0""#,
                 STRIP_SECTION
             ),
-            r#"[dependencies]
-time="0.1.25"
----
-fn main() {}
-"#
+            None
         )
     );
 
@@ -317,10 +311,7 @@ name = "n"
 version = "0.1.0""#,
                 STRIP_SECTION
             ),
-            r#"
-// Cargo-Deps: time="0.1.25"
-fn main() {}
-"#
+            None
         )
     );
 
@@ -347,10 +338,7 @@ name = "n"
 version = "0.1.0""#,
                 STRIP_SECTION
             ),
-            r#"
-// Cargo-Deps: time="0.1.25", libc="0.2.5"
-fn main() {}
-"#
+            None
         )
     );
 
@@ -383,17 +371,7 @@ name = "n"
 version = "0.1.0""#,
                 STRIP_SECTION
             ),
-            r#"
-/*!
-Here is a manifest:
-
-```cargo
-[dependencies]
-time = "0.1.25"
-```
-*/
-fn main() {}
-"#
+            None
         )
     );
 }
@@ -401,11 +379,11 @@ fn main() {}
 /**
 Returns a slice of the input string with the leading shebang, if there is one, omitted.
 */
-fn strip_shebang(s: &str) -> (&str, bool) {
+fn strip_shebang(s: &str) -> &str {
     let re_shebang: Regex = Regex::new(r"^#![^\[].*?(\r\n|\n)").unwrap();
     match re_shebang.find(s) {
-        Some(m) => (&s[m.end()..], true),
-        None => (s, false),
+        Some(m) => &s[m.end()..],
+        None => s,
     }
 }
 
@@ -1096,7 +1074,7 @@ Generates a default Cargo manifest for the given input.
 fn default_manifest(
     input: &Input,
     bin_name: &str,
-    script_name: &str,
+    bin_source_path: &str,
     toolchain: Option<String>,
 ) -> toml::value::Table {
     let mut package_map = toml::map::Map::new();
@@ -1144,9 +1122,10 @@ fn default_manifest(
         "name".to_string(),
         toml::value::Value::String(bin_name.to_string()),
     );
+
     bin_map.insert(
         "path".to_string(),
-        toml::value::Value::String(script_name.to_string()),
+        toml::value::Value::String(bin_source_path.to_string()),
     );
 
     let mut mani_map = toml::map::Map::new();

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -29,9 +29,9 @@ pub fn split_input(
     toolchain: Option<String>,
 ) -> MainResult<(String, PathBuf, Option<String>)> {
     fn contains_main_method(source: &str) -> bool {
-        let re_shebang: Regex =
+        let re_main: Regex =
             Regex::new(r#"(?m)^ *(pub )?(async )?(extern "C" )?fn main *\("#).unwrap();
-        re_shebang.is_match(source)
+        re_main.is_match(source)
     }
 
     let source_in_package = package_path.as_ref().join(script_name);

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -96,12 +96,16 @@ pub fn split_input(
     info!("part_mani: {:?}", part_mani);
     info!("source: {:?}", source);
 
-    let source_path_str = source_path
-        .to_str()
-        .ok_or_else(|| format!("Unable to stringify {source_path:?}"))?;
+    let source_path_from_package = if template.is_some() {
+        script_name
+    } else {
+        source_path
+            .to_str()
+            .ok_or_else(|| format!("Unable to stringify {source_path:?}"))?
+    };
 
     // It's-a mergin' time!
-    let def_mani = default_manifest(input, bin_name, source_path_str, toolchain);
+    let def_mani = default_manifest(input, bin_name, source_path_from_package, toolchain);
     let dep_mani = deps_manifest(deps)?;
 
     let mani = merge_manifest(def_mani, part_mani)?;
@@ -411,7 +415,7 @@ println!("Hello")"#)),
                 "{}{}",
                 r#"[[bin]]
 name = "binary-name"
-path = "/package/main.rs"
+path = "main.rs"
 
 [dependencies]
 
@@ -423,12 +427,15 @@ version = "0.1.0""#,
                 STRIP_SECTION
             ),
             "/package/main.rs",
-            Some(r#"
+            Some(
+                r#"
 fn main() -> Result<(), Box<dyn std::error::Error+Sync+Send>> {
     {println!("Hello")}
     Ok(())
 }
-"#.to_string())
+"#
+                .to_string()
+            )
         )
     );
 }


### PR DESCRIPTION
Context: https://github.com/fornwall/rust-script/issues/11#issuecomment-1516408804

This PR makes `rust-script` not generate the source file in the package directory if possible, and let `Cargo.toml` refer to the given script file as the binary source path in that case. This will let `cargo check` on the package directory output the original file path instead of the generated one, which makes `rust-analyzer` correctly treat it in fly check.