### PR TITLE
Mark tests which need internet access

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       with:
         toolchain: ${{ matrix.rust }}
     - name: Run unit tests
-      run: rustc --version && cargo --version && cargo test
+      run: rustc --version && cargo --version && cargo test --features online_tests
     - name: Run script tests
       if: runner.os != 'Windows'
       run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,3 +43,7 @@ scan-rules = "0.2"
 
 [profile.release]
 lto = true
+
+[features]
+default=[]
+online_tests=[]

--- a/tests/tests/expr.rs
+++ b/tests/tests/expr.rs
@@ -28,6 +28,7 @@ fn test_expr_temporary() {
     assert!(out.success());
 }
 
+#[cfg_attr(not(feature = "online_tests"), ignore)]
 #[test]
 fn test_expr_dep() {
     let out = rust_script!(

--- a/tests/tests/script.rs
+++ b/tests/tests/script.rs
@@ -1,3 +1,4 @@
+#[cfg_attr(not(feature = "online_tests"), ignore)]
 #[test]
 fn test_script_explicit() {
     let out = rust_script!("-d", "boolinator", "tests/data/script-explicit.rs").unwrap();
@@ -7,6 +8,7 @@ fn test_script_explicit() {
     .unwrap()
 }
 
+#[cfg_attr(not(feature = "online_tests"), ignore)]
 #[test]
 fn test_script_full_block() {
     let out = rust_script!("tests/data/script-full-block.rs").unwrap();
@@ -16,6 +18,7 @@ fn test_script_full_block() {
     .unwrap()
 }
 
+#[cfg_attr(not(feature = "online_tests"), ignore)]
 #[test]
 fn test_script_full_line() {
     let out = rust_script!("tests/data/script-full-line.rs").unwrap();
@@ -25,6 +28,7 @@ fn test_script_full_line() {
     .unwrap()
 }
 
+#[cfg_attr(not(feature = "online_tests"), ignore)]
 #[test]
 fn test_script_full_line_without_main() {
     let out = rust_script!("tests/data/script-full-line-without-main.rs").unwrap();
@@ -61,6 +65,7 @@ fn test_script_no_deps() {
     .unwrap()
 }
 
+#[cfg_attr(not(feature = "online_tests"), ignore)]
 #[test]
 fn test_script_short() {
     let out = rust_script!("tests/data/script-short.rs").unwrap();
@@ -70,6 +75,7 @@ fn test_script_short() {
     .unwrap()
 }
 
+#[cfg_attr(not(feature = "online_tests"), ignore)]
 #[test]
 fn test_script_short_without_main() {
     let out = rust_script!("tests/data/script-short-without-main.rs").unwrap();
@@ -133,6 +139,7 @@ fn test_script_including_relative() {
     .unwrap()
 }
 
+#[cfg_attr(not(feature = "online_tests"), ignore)]
 #[test]
 fn script_with_same_name_as_dependency() {
     let out = rust_script!("tests/data/time.rs").unwrap();
@@ -150,6 +157,7 @@ fn script_without_main_question_mark() {
         .starts_with("Error: Os { code: 2, kind: NotFound, message:"));
 }
 
+#[cfg_attr(not(feature = "online_tests"), ignore)]
 #[test]
 fn test_script_async_main() {
     let out = rust_script!("tests/data/script-async-main.rs").unwrap();
@@ -159,6 +167,7 @@ fn test_script_async_main() {
     .unwrap()
 }
 
+#[cfg_attr(not(feature = "online_tests"), ignore)]
 #[test]
 fn test_pub_fn_main() {
     let out = rust_script!("tests/data/pub-fn-main.rs").unwrap();
@@ -177,6 +186,7 @@ fn test_cargo_target_dir_env() {
     .unwrap()
 }
 
+#[cfg_attr(not(feature = "online_tests"), ignore)]
 #[test]
 fn test_outer_line_doc() {
     let out = rust_script!("tests/data/outer-line-doc.rs").unwrap();
@@ -262,6 +272,7 @@ fn test_same_flags() {
 }
 
 #[cfg(unix)]
+#[cfg_attr(not(feature = "online_tests"), ignore)]
 #[test]
 fn test_extern_c_main() {
     let out = rust_script!("tests/data/extern-c-main.rs").unwrap();


### PR DESCRIPTION
Tests which depend on downloading dependency crates will fail when executed in an environment which has no internet access. To allow for offline testing, these tests are only enabled with the "online_tests" feature.

To run all tests, including those which need internet access, it is now necessary to run:

    cargo test --features online_tests