### PR TITLE
Add support for -w/--wrapper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,10 @@ jobs:
       uses: dtolnay/rust-toolchain@stable
       with:
         toolchain: ${{ matrix.rust }}
-    - name: Install just
-      uses: taiki-e/install-action@just
+    - name: Setup homebrew
+      uses: Homebrew/actions/setup-homebrew@master
+    - name: Install hyperfine and just
+      run: brew install hyperfine just
     - name: Install rust-script
       run: cargo install --path .
     - name: Test examples

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,6 +444,7 @@ dependencies = [
  "regex",
  "scan-rules",
  "sha1",
+ "shell-words",
  "tempfile",
  "toml",
  "winreg",
@@ -491,9 +492,9 @@ checksum = "d4f410fedcf71af0345d7607d246e7ad15faaadd49d240ee3b24e5dc21a820ac"
 
 [[package]]
 name = "serde"
-version = "1.0.180"
+version = "1.0.181"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea67f183f058fe88a4e3ec6e2788e003840893b91bac4559cabedd00863b3ed"
+checksum = "6d3e73c93c3240c0bda063c239298e633114c69a888c3e37ca8bb33f343e9890"
 
 [[package]]
 name = "serde_spanned"
@@ -514,6 +515,12 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
+
+[[package]]
+name = "shell-words"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
 
 [[package]]
 name = "strcursor"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ log = "0.4"
 pulldown-cmark = "0.9"
 regex = "1"
 sha1 = "0.10"
+shell-words = "1"
 tempfile = "3"
 toml = "0.7"
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -107,6 +107,7 @@ Useful command-line arguments:
 - `--force`: Force the script to be rebuilt.  Useful if you want to force a recompile with a different toolchain.
 - `--package`: Generate the Cargo package and print the path to it - but don't compile or run it. Effectively "unpacks" the script into a Cargo package.
 - `--test`: Compile and run tests.
+- `--wrapper`: Add a wrapper around the executable. Can be used to run debugging with e.g. `rust-script --wrapper rust-lldb my-script.rs` or benchmarking with `rust-script --wrapper "hyperfine --runs 100" my-script.rs`
 
 ## Executable Scripts
 

--- a/examples/fib.ers
+++ b/examples/fib.ers
@@ -1,0 +1,13 @@
+#!/usr/bin/env rust-script
+
+fn fib(n: i32) -> i32 {
+  match n {
+    1 | 2 => 1,
+    _ => fib(n-1) + fib(n-2)
+  }
+}
+
+fn main() {
+  assert_eq!(fib(30), 832040);
+}
+

--- a/examples/test-examples.sh
+++ b/examples/test-examples.sh
@@ -11,3 +11,14 @@ assert_equals() {
 assert_equals "result: 3" "$(just -f justfile/Justfile)"
 assert_equals "hello, rust" "$(./hello.ers)"
 assert_equals "hello, rust" "$(./hello-without-main.ers)"
+
+HYPERFINE_OUTPUT=$(rust-script --wrapper "hyperfine --runs 99" fib.ers)
+
+case "$HYPERFINE_OUTPUT" in
+  *"99 runs"*)
+    ;;
+  *)
+    echo "Hyperfine output: $HYPERFINE_OUTPUT"
+    exit 1
+    ;;
+esac

--- a/src/arguments.rs
+++ b/src/arguments.rs
@@ -25,6 +25,7 @@ pub struct Args {
     pub install_file_association: bool,
     #[cfg(windows)]
     pub uninstall_file_association: bool,
+    pub wrapper: Option<String>,
 }
 
 impl Args {
@@ -75,7 +76,7 @@ impl Args {
                 .help("Base path for resolving dependencies")
                 .short('b')
                 .long("base-path")
-                .num_args(1..=1)
+                .num_args(1)
             )
             .arg(Arg::new("cargo-output")
                 .help("Show output from cargo when building")
@@ -163,6 +164,12 @@ impl Args {
                 .num_args(1)
                 // Benchmarking currently requires nightly:
                 .conflicts_with("bench")
+            )
+            .arg(Arg::new("wrapper")
+                .help("Wrapper injected before the command to run, e.g. 'rust-lldb' or 'hyperfine --runs 100'")
+                .long("wrapper")
+                .short('w')
+                .num_args(1)
             );
 
         #[cfg(windows)]
@@ -240,6 +247,7 @@ impl Args {
             install_file_association: m.get_flag("install-file-association"),
             #[cfg(windows)]
             uninstall_file_association: m.get_flag("uninstall-file-association"),
+            wrapper: m.get_one::<String>("wrapper").map(Into::into),
         }
     }
 }


### PR DESCRIPTION
Support `-w`/`--wrapper` for specifying a wrapper around the executable. This can be used to run e.g. rust-gdb (#54) or hyperfine. Examples:

- `rust-script --wrapper rust-lldb my-script.rs`
- `rust-script --wrapper "hyperfine --runs 100" my-script.rs`
