### PR TITLE
Fix testcase for `rust-script --test`

### DIFF
--- a/tests/data/script-test.rs
+++ b/tests/data/script-test.rs
@@ -1,2 +1,4 @@
+fn main() {}
+
 #[test]
 fn test() {}

--- a/tests/tests/script.rs
+++ b/tests/tests/script.rs
@@ -89,6 +89,7 @@ fn test_script_short_without_main() {
 fn test_script_test() {
     let out = rust_script!("--test", "tests/data/script-test.rs").unwrap();
     assert!(out.success());
+    assert!(out.stdout.contains("running 1 test"));
 }
 
 #[test]


### PR DESCRIPTION
The `rust-script` now supports the execution of test cases within scripts using the `--test` parameter. It also includes a built-in test case named `test_script_test`, which runs the test cases in `tests/data/script-test.rs` to perform functionality testing on `rust-script` itself.

When executing this test case with `cargo test`, everything appears to be functioning correctly:


```bash
❯ cargo test script_test
   Compiling rust-script v0.35.0 (/Users/leemars/Workspace/github/rust-script)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 1.30s
     Running unittests src/main.rs (target/debug/deps/rust_script-ae3b655340e83841)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 5 filtered out; finished in 0.00s

     Running tests/integration.rs (target/debug/deps/integration-2ca641bad340c0b5)

running 1 test
test tests::script::test_script_test ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 36 filtered out; finished in 1.04s
```

However, when using `cargo test -- --nocapture` to view all output, it is observed that the test cases in `tests/data/script-test.rs` are not actually being executed:

```bash
❯ cargo test script_test -- --nocapture
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.07s
     Running unittests src/main.rs (target/debug/deps/rust_script-ae3b655340e83841)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 5 filtered out; finished in 0.00s

     Running tests/integration.rs (target/debug/deps/integration-2ca641bad340c0b5)

running 1 test
rust-script cmd: env -u CARGO_TARGET_DIR "target/debug/rust-script" "--test" "tests/data/script-test.rs"
rust-script stdout:
-----

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


-----
rust-script stderr:
-----
warning: cannot test inner items
 --> script-test.rs:3:6
  |
3 |     {#[test]
  |      ^^^^^^^
  |
  = note: `#[warn(unnameable_test_items)]` on by default
  = note: this warning originates in the attribute macro `test` (in Nightly builds, run with -Z macro-backtrace for more info)

warning: `script-test_d506f690073d73f30b06495c` (bin "script-test_d506f690073d73f30b06495c" test) generated 1 warning
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.00s
     Running unittests script-test.rs (/Users/leemars/Library/Caches/rust-script/binaries/debug/deps/script_test_d506f690073d73f30b06495c-1f12e40887bd5fb2)

-----
test tests::script::test_script_test ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 36 filtered out; finished in 0.68s
```

Based on the error messages, I speculate that this issue arises due to the way `rust-script` works. If a script does not provide a main function, `rust-script` wraps the entire script within a main function body for execution. This results in `#[test]` test cases appearing inside a function, which is currently unsupported by Rust for discovering tests within functions.

To fix this, I have added an empty main function to `tests/data/script-test.rs` to prevent `rust-script` from performing additional wrapping and have confirmed that a test case is executed during testing.

Welcome any feedback or suggestions for improvement.