### PR TITLE
Allow passing additional arguments to `cargo test` and `cargo bench` in `rust-script`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -477,6 +477,8 @@ impl InputAction {
             } else {
                 return Err(MainError::OtherOwned("Could not execute cargo".to_string()));
             }
+        } else {
+            cmd.args(script_args.iter());
         }
 
         Ok(cmd)

--- a/tests/data/script-test-extra-args.rs
+++ b/tests/data/script-test-extra-args.rs
@@ -1,0 +1,4 @@
+fn main() {}
+
+#[test]
+fn test() { println!("Hello, world!"); }

--- a/tests/tests/script.rs
+++ b/tests/tests/script.rs
@@ -92,6 +92,20 @@ fn test_script_test() {
 }
 
 #[test]
+fn test_script_test_extra_args_for_cargo() {
+    let out = rust_script!("--test", "tests/data/script-test-extra-args.rs", "--help").unwrap();
+    assert!(out.success());
+    assert!(out.stdout.contains("Usage: cargo test "));
+}
+
+#[test]
+fn test_script_test_extra_args_for_test() {
+    let out = rust_script!("--test", "tests/data/script-test-extra-args.rs", "--", "--nocapture").unwrap();
+    assert!(out.success());
+    assert!(out.stdout.contains("Hello, world!"));
+}
+
+#[test]
 fn test_script_hyphens() {
     use scan_rules::scanner::QuotedString;
     let out = rust_script!("--", "tests/data/script-args.rs", "-NotAnArg").unwrap();


### PR DESCRIPTION
Based on the information from [Stack Overflow](https://stackoverflow.com/a/25107081), when executing tests with `cargo test`, the `--nocapture` flag is required to display the output of `println!` in Rust tests. However, the current implementation of `rust-script` ignores all additional arguments when executing scripts with the `--test` flag (and likely also with the `--bench` mode, based on the code).

To fix this, I propose a minor change: when the `build_kind` is not `Normal` (i.e., when it's `Test` or `Bench`), we append `script_args` to the command line.

Although this is a small change, considering the complexity of real-world environments, I am not certain whether supporting the passing of additional arguments to `cargo test`, `cargo bench`, and the tested programs will introduce any additional security issues (hopefully not).

Welcome any feedback or suggestions for improvement. 

