### PR TITLE
Replace is-terminal with standard library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,12 +246,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
-name = "hermit-abi"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
-
-[[package]]
 name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -265,17 +259,6 @@ checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
 dependencies = [
  "equivalent",
  "hashbrown",
-]
-
-[[package]]
-name = "is-terminal"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -432,7 +415,6 @@ dependencies = [
  "clap",
  "dirs",
  "env_logger",
- "is-terminal",
  "lazy_static 1.5.0",
  "log",
  "pulldown-cmark",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,9 +35,6 @@ toml = "0.8"
 [target.'cfg(windows)'.dependencies]
 winreg = "0.52"
 
-[target.'cfg(unix)'.dependencies]
-is-terminal = "0.4.6"
-
 [dev-dependencies]
 lazy_static = "1"
 scan-rules = "0.2"

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -54,7 +54,7 @@ pub fn binary_cache_path() -> PathBuf {
 
 #[cfg(unix)]
 mod inner {
-    use is_terminal::IsTerminal as _;
+    use std::io::IsTerminal as _;
 
     /**
     Returns `true` if `rust-script` should force Cargo to use coloured output.


### PR DESCRIPTION
`std::io::IsTerminal` can be used as it is stabilized at Rust 1.70.
