### PR TITLE
Fix issue with --clear-cache when "projects" directory doesn't exist

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -239,26 +239,29 @@ fn clean_cache(max_age: u128) -> MainResult<()> {
     info!("cutoff:     {:>20?} ms", cutoff);
 
     let cache_dir = platform::generated_projects_cache_path();
-    for child in fs::read_dir(cache_dir)? {
-        let child = child?;
-        let path = child.path();
-        if path.is_file() {
-            continue;
-        }
 
-        info!("checking: {:?}", path);
-
-        let remove_dir = || {
-            let meta_mtime = platform::dir_last_modified(&child);
-            info!("meta_mtime: {:>20?} ms", meta_mtime);
-
-            meta_mtime <= cutoff
-        };
-
-        if remove_dir() {
-            info!("removing {:?}", path);
-            if let Err(err) = fs::remove_dir_all(&path) {
-                error!("failed to remove {:?} from cache: {}", path, err);
+    if cache_dir.exists(){
+        for child in fs::read_dir(cache_dir)? {
+            let child = child?;
+            let path = child.path();
+            if path.is_file() {
+                continue;
+            }
+            
+            info!("checking: {:?}", path);
+            
+            let remove_dir = || {
+                let meta_mtime = platform::dir_last_modified(&child);
+                info!("meta_mtime: {:>20?} ms", meta_mtime);
+                
+                meta_mtime <= cutoff
+            };
+            
+            if remove_dir() {
+                info!("removing {:?}", path);
+                if let Err(err) = fs::remove_dir_all(&path) {
+                    error!("failed to remove {:?} from cache: {}", path, err);
+                }
             }
         }
     }


### PR DESCRIPTION
When running rust-script with `--clear-cache` and the _projects_ cache directory doesn't exist, an error will be thrown without running the underlaying script.

```shell
RUST_LOG=info rust-script --clear-cache scripts/generate_docs_api_spec.rs
[2025-05-13T13:25:25Z INFO  rust_script] Arguments: Args { script: Some("scripts/generate_docs_api_spec.rs"), script_args: [], expr: false, loop_: false, count: false, base_path: None, pkg_path: None, gen_pkg_only: false, cargo_output: false, clear_cache: true, debug: false, dep: [], extern_: [], force: false, unstable_features: [], build_kind: Normal, toolchain_version: None, wrapper: None }
[2025-05-13T13:25:25Z INFO  rust_script] cleaning cache with max_age: 0
[2025-05-13T13:25:25Z INFO  rust_script] max_age is 0, clearing binary cache...
[2025-05-13T13:25:25Z INFO  rust_script] cutoff:            1747142725179 ms
error: No such file or directory (os error 2)
```

The issue can be replicated by running the following:
```shell
rm -r /home/$USER/.cache/rust-script/projects
rust-script --clear-cache scripts/<some_script.rs>
```
This means that it will also happen if `--clear-cache` is used in the first execution after installation.

I believe the natural behavior should be to ignore the error and proceed with the script execution (thus creating the cache folder).